### PR TITLE
Update workflow to use original and translate comments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,85 +1,84 @@
-# 📄 GitHub Actions Workflow: Publish Web Map
-
+# 📄 Flujo de trabajo de GitHub Actions: Publicar mapa web
 name: Publish Web Map
 
-# 🕒 Trigger the workflow daily at 03:00 UTC, on push, and allow manual runs
+# 🕒 Activa el flujo de trabajo diariamente a las 03:00 UTC, en cada push y permite ejecuciones manuales
 on:
   push:
   schedule:
-    - cron: '0 3 * * *'  # Runs daily at 03:00 UTC
+    - cron: '0 3 * * *'  # Se ejecuta diariamente a las 03:00 UTC
   workflow_dispatch:
 
-# 🔐 Set permissions for the workflow
+# 🔐 Establecer permisos para el flujo de trabajo
 permissions:
-  contents: write       # To push changes to the repository
-  pages: write          # To deploy to GitHub Pages
-  id-token: write       # Required for GitHub Pages deployment
+  contents: write       # Para enviar cambios al repositorio
+  pages: write          # Para desplegar en GitHub Pages
+  id-token: write       # Requerido para el despliegue en GitHub Pages
 
-# 🛠️ Define the jobs to be run
+# 🛠️ Definir los trabajos a ejecutar
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      # 📥 Step 1: Checkout the repository code
+      # 📥 Paso 1: Clonar el código del repositorio
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch full history for git operations
+          fetch-depth: 0  # Obtener el historial completo para operaciones de git
 
-      # 🐍 Step 2: Set up Python environment
+      # 🐍 Paso 2: Configurar el entorno de Python
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'  # Specify the Python version
+          python-version: '3.11'  # Especificar la versión de Python
 
-      # 📦 Step 3: Install Python dependencies
+      # 📦 Paso 3: Instalar dependencias de Python
       - name: Install Dependencies
         run: |
           pip install -r requirements.txt
 
-      # 🗺️ Step 4: Generate the web map
+      # 🗺️ Paso 4: Generar el mapa web
       - name: Generate Map
         run: |
-          python make_map.py  # Run the script to create index.html in the 'map' directory
+          python make_map.py  # Ejecutar el script para crear index.html en el directorio 'map'
 
-      # ⚙️ Step 5: Configure Git for committing changes
+      # ⚙️ Paso 5: Configurar Git para confirmar cambios
       - name: Configure Git
         run: |
-          git config user.name "${{ github.actor }}"  # Set Git username
-          git config user.email "${{ github.actor }}@users.noreply.github.com"  # Set Git email
+          git config user.name "${{ github.actor }}"  # Establecer nombre de usuario de Git
+          git config user.email "${{ github.actor }}@users.noreply.github.com"  # Establecer correo electrónico de Git
 
-      # 🔄 Step 6: Pull latest changes to prevent non-fast-forward errors
+      # 🔄 Paso 6: Obtener los últimos cambios para evitar errores de non-fast-forward
       - name: Pull Latest Changes
         run: |
-          git pull origin main  # Update local branch with remote changes
+          git pull origin main  # Actualizar la rama local con los cambios remotos
 
-      # 💾 Step 7: Commit and push changes
+      # 💾 Paso 7: Confirmar y enviar cambios
       - name: Commit and Push Changes
         run: |
           git add . 
           git commit -m "Update index.html with latest map data" || echo "No changes to commit"
-          git push origin main  # Push changes to the repository
+          git push origin main  # Enviar cambios al repositorio
 
-      # 📤 Step 8: Upload the 'map' directory as an artifact for deployment
+      # 📤 Paso 8: Subir el directorio 'map' como un artefacto para el despliegue
       - name: Upload Artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          name: github-pages  # Name of the artifact
-          path: ./  # Directory to upload
+          name: github-pages  # Nombre del artefacto
+          path: ./  # Directorio a subir
 
   deploy:
-    # 🚀 Deployment job depends on the 'build' job
+    # 🚀 El trabajo de despliegue depende del trabajo de 'build'
     needs: build
     runs-on: ubuntu-latest
 
-    # 🌐 Define the deployment environment
+    # 🌐 Definir el entorno de despliegue
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}  # URL of the deployed site
+      url: ${{ steps.deployment.outputs.page_url }}  # URL del sitio desplegado
 
     steps:
-      # 🚀 Step 9: Deploy the uploaded artifact to GitHub Pages
+      # 🚀 Paso 9: Desplegar el artefacto subido en GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# folium-webmap-tutorial
-A very basic tutorial on how to easily publish an webmap using Folium, Geopandas, OSMNX, GitHub Pages and Github Actions
+# Tutorial de Webmap con Folium
+
+Este repositorio es un tutorial y una plantilla básica para crear y publicar fácilmente un mapa web interactivo. Utiliza Python con las bibliotecas Folium, GeoPandas y OSMnx para generar el mapa, y se despliega automáticamente en GitHub Pages a través de GitHub Actions.
+
+## ¿Cómo usar esta plantilla?
+
+El objetivo de este proyecto es que puedas crear tu propio mapa con mínimos cambios. Simplemente sigue estos pasos:
+
+1.  **Haz un fork de este repositorio:** Esto creará una copia en tu propia cuenta de GitHub.
+2.  **Modifica el archivo `make_map.py`:**
+    *   Cambia el valor de la variable `place` para definir la ubicación geográfica de tu mapa (por ejemplo, `"Madrid, Spain"`).
+    *   Ajusta las `tags` de OpenStreetMap para seleccionar las características que quieres mostrar en el mapa (por ejemplo, `{"amenity": "restaurant"}` para restaurantes).
+3.  **Guarda los cambios (commit):** Una vez que guardes los cambios en tu repositorio, una acción de GitHub se ejecutará automáticamente.
+4.  **¡Listo!** La acción generará un archivo `index.html` y lo publicará en GitHub Pages. Podrás ver tu mapa en una URL como `https://<tu-usuario>.github.io/<nombre-del-repositorio>/`.
+
+Este proyecto es ideal para quienes deseen visualizar datos geoespaciales de forma rápida y sencilla sin necesidad de configurar un servidor web complejo.

--- a/make_map.py
+++ b/make_map.py
@@ -1,34 +1,34 @@
-# 1. Import required libraries
+# 1. Importar las bibliotecas necesarias
 import osmnx as ox
 import geopandas as gpd
 import folium
 from folium.plugins import MarkerCluster
 
-# 2. Define the geographic area and feature tags to download
+# 2. Definir el área geográfica y las etiquetas de las características a descargar
 place = "Curitiba, Brazil"
 tags = {"highway": "bus_stop"}
 description = "Bus Stop"
 zoom_level = 13
 
-# 3. Specify which fields to show inside marker popups
+# 3. Especificar qué campos mostrar dentro de las ventanas emergentes de los marcadores
 popup_fields = ["name", "operator", "network", "ref"]
 
-# 4. Download bus stop features from OpenStreetMap for the chosen place
+# 4. Descargar las características de las paradas de autobús de OpenStreetMap para el lugar elegido
 gdf = ox.features_from_place(place, tags=tags)
 
-# 5. Ensure the GeoDataFrame is in the latitude/longitude coordinate system
+# 5. Asegurarse de que el GeoDataFrame esté en el sistema de coordenadas de latitud/longitud
 gdf = gdf.to_crs(epsg=4326)
 
-# 6. Add any missing columns so popups don't break
+# 6. Añadir las columnas que falten para que las ventanas emergentes no se rompan
 for field in popup_fields:
     if field not in gdf.columns:
         gdf[field] = ""
 
-# 7. Compute the centroid of all bus stops to center the map
+# 7. Calcular el centroide de todas las paradas de autobús para centrar el mapa
 centroid = gdf.union_all().centroid
 center_latlon = [centroid.y, centroid.x]
 
-# 8. Create a Folium map and add a few base tile layers
+# 8. Crear un mapa Folium y añadir algunas capas de teselas base
 m = folium.Map(location=center_latlon, zoom_start=zoom_level, tiles=None)
 folium.TileLayer("CartoDB positron", name="CartoDB Positron").add_to(m)
 folium.TileLayer("OpenStreetMap", name="OpenStreetMap").add_to(m)
@@ -38,7 +38,7 @@ folium.TileLayer(
     attr="Map tiles by Stamen Design, CC BY 3.0 — Map data © OpenStreetMap contributors",
 ).add_to(m)
 
-# 9. Add bus stop markers to the map using a MarkerCluster plugin
+# 9. Añadir marcadores de paradas de autobús al mapa utilizando un plugin MarkerCluster
 marker_cluster = MarkerCluster(name="Bus Stops (Cluster)").add_to(m)
 for _, row in gdf.iterrows():
     coords = row.geometry
@@ -48,7 +48,7 @@ for _, row in gdf.iterrows():
             popup=row.get("name", description),
         ).add_to(marker_cluster)
 
-# 10. Add a plain GeoJSON layer with interactive circle markers
+# 10. Añadir una capa GeoJSON simple con marcadores circulares interactivos
 interactive_layer = folium.GeoJson(
     gdf,
     name="Bus Stops (Points)", show=False,
@@ -59,8 +59,8 @@ interactive_layer = folium.GeoJson(
     popup=folium.GeoJsonPopup(fields=popup_fields, labels=True),
 ).add_to(m)
 
-# 11. Try to fetch and display the administrative boundary polygon
-#     OpenStreetMap uses the "admin_level" tag for such boundaries:
+# 11. Intentar obtener y mostrar el polígono del límite administrativo
+#     OpenStreetMap utiliza la etiqueta "admin_level" para dichos límites:
 #     https://wiki.openstreetmap.org/wiki/Key:admin_level
 try:
     boundary_gdf = ox.geocode_to_gdf(place).to_crs(epsg=4326)
@@ -72,8 +72,8 @@ try:
 except Exception:
     pass
 
-# 12. Allow the user to toggle layers on and off
+# 12. Permitir al usuario activar y desactivar las capas
 folium.LayerControl().add_to(m)
 
-# 13. Save the map to an HTML file
+# 13. Guardar el mapa en un archivo HTML
 m.save("index.html")


### PR DESCRIPTION
Based on user feedback, this commit reverts the workflow changes to use the original `publish.yml` file and translates its comments to Spanish.

- Restored the `publish.yml` workflow.
- Deleted the `deploy.yml` workflow.
- Translated the comments in `publish.yml` to Spanish.